### PR TITLE
Add endpoint to fetch all developer with their revenue

### DIFF
--- a/src/domain/developers/repositories/developers.repository.ts
+++ b/src/domain/developers/repositories/developers.repository.ts
@@ -3,7 +3,7 @@
 // **************************************************************************
 
 import { injectable } from 'inversify';
-import { IDeveloper } from '../types'
+import { IDeveloper, IRevenue } from '../types'
 import { contracts, developers } from './data'
 
 @injectable()
@@ -11,6 +11,13 @@ export class DevelopersRepository {
 
 	async getDevelopers(): Promise<IDeveloper[]>{
 		return developers
+	}
+
+	async getDevelopersWithRevenues(): Promise<(IDeveloper & IRevenue)[]>{
+		return developers.map((d) => {
+			const revenue = contracts.reduce((acc, c) => c.developerId === d.id && c.status === 'completed'? acc + c.amount : acc, 0)
+			return {...d, revenue}
+		})
 	}
 
 	async getDeveloperById(id: string): Promise<IDeveloper>{

--- a/src/domain/developers/services/developers.service.ts
+++ b/src/domain/developers/services/developers.service.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { DevelopersRepository } from '../repositories/developers.repository';
-import { IDeveloper } from '../types'
+import { IDeveloper, IRevenue } from '../types'
 
 @injectable()
 export class DevelopersService {
@@ -11,6 +11,10 @@ export class DevelopersService {
 
 	async getDevelopers(): Promise<IDeveloper[]>{
 		return this.developersRepository.getDevelopers()
+	}
+
+	async getDevelopersWithRevenues(): Promise<(IDeveloper & IRevenue)[]>{
+		return this.developersRepository.getDevelopersWithRevenues()
 	}
 
 	async getDeveloperById(id: string){

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -8,3 +8,7 @@ export interface IDeveloper {
 	email: string
 
 }
+
+export interface IRevenue {
+	revenue?: number
+}

--- a/src/rest/controllers/developers.controller.ts
+++ b/src/rest/controllers/developers.controller.ts
@@ -6,11 +6,11 @@ import {
 } from 'inversify-express-utils';
 import { ApiOperationGet, ApiPath } from 'swagger-express-ts';
 import {
-	path, getDevelopers, getDeveloperById
+	path, getDevelopers, getDeveloperById, getDevelopersWithRevenues
 } from '../swagger/developers.swagger.docs';
 import { inject } from 'inversify'
 import { DevelopersService } from '../../domain/developers/services/developers.service'
-import { DeveloperDto } from '../dto/developers.responses.dto'
+import { DeveloperDto, DeveloperWithRevenueDto } from '../dto/developers.responses.dto'
 
 @controller('/api/developers')
 @ApiPath(path)
@@ -24,6 +24,12 @@ export class DevelopersController extends BaseHttpController implements interfac
 	@ApiOperationGet(getDevelopers)
 	public async getDevelopers(): Promise<DeveloperDto[]> {
 		return this.developersService.getDevelopers()
+	}
+
+	@httpGet('/completedRevenues')
+	@ApiOperationGet(getDevelopersWithRevenues)
+	public async getDevelopersWithRevenue(): Promise<DeveloperWithRevenueDto[]> {
+		return this.developersService.getDevelopersWithRevenues()
 	}
 
 	@httpGet('/:id')

--- a/src/rest/dto/developers.responses.dto.ts
+++ b/src/rest/dto/developers.responses.dto.ts
@@ -1,5 +1,5 @@
 import { ApiModel, ApiModelProperty } from 'swagger-express-ts'
-import { IDeveloper } from '../../domain/developers/types'
+import { IDeveloper, IRevenue } from '../../domain/developers/types'
 
 @ApiModel()
 export class DeveloperDto implements IDeveloper {
@@ -17,4 +17,23 @@ export class DeveloperDto implements IDeveloper {
 	email: string
 
 
+}
+
+@ApiModel()
+export class DeveloperWithRevenueDto implements IDeveloper, IRevenue {
+
+	@ApiModelProperty()
+	id: string
+
+	@ApiModelProperty()
+	firstName?: string
+
+	@ApiModelProperty()
+	lastName?: string
+
+	@ApiModelProperty()
+	email: string
+
+	@ApiModelProperty()
+	revenue?: number
 }

--- a/src/rest/swagger/developers.swagger.docs.ts
+++ b/src/rest/swagger/developers.swagger.docs.ts
@@ -7,7 +7,7 @@ export const path: IApiPathArgs = {
 }
 
 export const getDevelopers: IApiOperationArgsBase = {
-	summary: "Get full list of developers (used by developers management dashboard and contracts management dashboard)",
+	summary: "Get full list of developers (used by contracts management dashboard)",
 	path: '/',
 	parameters: {
 	},
@@ -15,6 +15,19 @@ export const getDevelopers: IApiOperationArgsBase = {
 		200: {
 			description: 'Success',
 			type: 'array', model: 'DeveloperDto'
+		},
+	},
+}
+
+export const getDevelopersWithRevenues: IApiOperationArgsBase = {
+	summary: "Get full list of developers with their revenue by all complited contracts (used by developers management dashboard)",
+	path: '/completedRevenues',
+	parameters: {
+	},
+	responses: {
+		200: {
+			description: 'Success',
+			type: 'array', model: 'DeveloperWithRevenueDto'
 		},
 	},
 }

--- a/test/developers.test.ts
+++ b/test/developers.test.ts
@@ -3,6 +3,11 @@ import { request } from './setup/shortcuts'
 import { createRequestWithContainerOverrides } from './setup/helpers'
 import { DevelopersRepository } from '../src/domain/developers/repositories/developers.repository'
 
+const expectedRevenueResult = {
+	'65de346c255f31cb84bd10e9': 12000,
+	'65de346a255f31cb84bd0e01': 11000,
+}
+
 describe('Developers API tests examples', () => {
 
 	it('should BAT fetch developers (e2e, real repository used)', async () => {
@@ -48,4 +53,23 @@ describe('Developers API tests examples', () => {
 
 	})
 
+	it('should BAT fetch developers with revenue and calculate revenue correctly', async () => {
+	
+		const result = await request.get(`/api/developers/completedRevenues`)
+
+		expect(result.status).toBe(200)
+		expect(result.body?.length).toBeGreaterThan(0)
+
+		for( const developer of result.body ){
+			console.log(developer)
+			expect(developer).toHaveProperty('id')
+			expect(developer).toHaveProperty('firstName')
+			expect(developer).toHaveProperty('lastName')
+			expect(developer).toHaveProperty('email')
+			expect(developer).toHaveProperty('revenue')
+			expect(developer.revenue).toEqual(expectedRevenueResult[developer.id] ?? 0)
+			
+		}
+
+	})
 })


### PR DESCRIPTION
Based on current project input an task the optimal way to solve this task is adding a new endpoint which gets data for all developers and their revenues.

- Data is joined and aggregated on db layer, as in real world project with databases it's better to do on that layer as it's more efficient than doing with js
- There was added a new endpoint but not updated current one `api/developers` as it's used by contracts management dashboard and it possible don't need to have revenue data, so we exclude unneeded calculation/aggregation
- Added test to verify calculated results based on test data

There are various other solution how to achieve getting revenues and join them with developers which could be used based on other addition requirements

<img width="1415" alt="Screenshot 2024-07-03 at 15 40 16" src="https://github.com/ksenialukova/backend-developer-test-task-master/assets/46114132/87b99c58-8ea3-42e3-9995-94c7c8e2764e">

<img width="1378" alt="Screenshot 2024-07-03 at 15 41 22" src="https://github.com/ksenialukova/backend-developer-test-task-master/assets/46114132/409ee689-ad3f-4975-946c-f1c388e101be">
